### PR TITLE
Add options to New, WithContext option for cancellation

### DIFF
--- a/sse_test.go
+++ b/sse_test.go
@@ -283,3 +283,17 @@ func TestJSONErr(t *testing.T) {
 		t.Fatal("wrong body, got:\n", w.written, "\nexpected:\n", expected)
 	}
 }
+
+func TestWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	streamer := New(WithContext(ctx))
+	w := NewMockResponseWriteFlusher()
+
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		cancel()
+	}()
+
+	streamer.ServeHTTP(w, NewMockRequestWithTimeout(5000*time.Millisecond))
+}


### PR DESCRIPTION
Saw this [reddit post](https://www.reddit.com/r/golang/comments/12kwq0n/howto_cancel_a_goroutine/) where someone was struggling to cancel a streamer that was hung.

This PR adds the following:
- An internal `context.Context` to the Streamer struct which is used for checking for external cancellation via the contexts `Done()` channel.
- Variadic options input to the `New` constructor to allow for additional user configuration of the Streamer.
- `WithContext` options function allowing for a context to be provided by the caller.

I'm not sure if this is the right approach, but wanted to offer it as a possible solution and hopefully help with the reddit post's question.